### PR TITLE
Try to detect DB url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .ipynb_checkpoints
 __pycache__/
+
+# Python venv
+bin/
+lib/

--- a/README.md
+++ b/README.md
@@ -27,10 +27,19 @@ Alternatively, to load from a cloud database we load from a json file containing
 
 We use the DataParser class to load data from the database. This class performs the SQL queries and parses the returned data. The class holds the master pandas dataframe master_df.
 
+If you are running under Hass.io or are using the default configuration path, `HassDatabase` will be able to automatically detect your database url. If not, you can pass in either the `url` or `hass_config_path`.
 
 ```python
 %%time
-db = detective.HassDatabase(DB_URL) # To init without fetching entities fetch_entities=False
+# Example invocations
+# Auto detect
+db = detective.HassDatabase()
+# using DB url
+db = detective.HassDatabase(url=DB_URL)
+# Using HASS config path
+db = detective.HassDatabase(hass_config_path='/home/homeassistant/config')
+# Auto detect and not prefetching entities
+db = detective.HassDatabase(fetch_entities=False)
 ```
 
     Successfully connected to sqlite:////Users/robincole/Documents/Home-assistant_database/home-assistant_v2.db

--- a/README.md
+++ b/README.md
@@ -31,15 +31,16 @@ If you are running under Hass.io or are using the default configuration path, `H
 
 ```python
 %%time
+from detective.core import HassDatabase
 # Example invocations
 # Auto detect
-db = detective.HassDatabase()
+db = HassDatabase()
 # using DB url
-db = detective.HassDatabase(url=DB_URL)
+db = HassDatabase(url=DB_URL)
 # Using HASS config path
-db = detective.HassDatabase(hass_config_path='/home/homeassistant/config')
+db = HassDatabase(hass_config_path='/home/homeassistant/config')
 # Auto detect and not prefetching entities
-db = detective.HassDatabase(fetch_entities=False)
+db = HassDatabase(fetch_entities=False)
 ```
 
     Successfully connected to sqlite:////Users/robincole/Documents/Home-assistant_database/home-assistant_v2.db

--- a/detective/core.py
+++ b/detective/core.py
@@ -13,13 +13,24 @@ class HassDatabase():
     Initializing the parser fetches all of the data from the database and
     places it in a master pandas dataframe.
     """
-    def __init__(self, url, fetch_entities=True):
+    def __init__(self, url=None, hass_config_path=None, fetch_entities=True):
         """
         Parameters
         ----------
         url : str
             The URL to the database.
         """
+        if url is None:
+            if hass_config_path is None:
+                hass_config_path = helpers.find_hass_config()
+
+            if hass_config_path:
+                url = helpers.db_url_from_hass_config(hass_config_path)
+
+        if url is None:
+            raise ValueError('Unable to detect Home Assistant. '
+                             'Pass in `url` or `hass_config_path`')
+
         self._url = url
         self._master_df = None
         try:

--- a/detective/helpers.py
+++ b/detective/helpers.py
@@ -2,6 +2,10 @@
 Helper functions.
 """
 import json
+import os
+
+from ruamel.yaml import YAML
+from ruamel.yaml.constructor import SafeConstructor
 
 
 def binary_state(value):
@@ -88,3 +92,87 @@ def load_url(filename):
         print('Failed to load url')
         url = None
     return url['url']
+
+
+def default_hass_config_dir():
+    """Put together the default configuration directory based on the OS."""
+    data_dir = os.getenv('APPDATA') if os.name == "nt" \
+        else os.path.expanduser('~')
+    return os.path.join(data_dir, '.homeassistant')
+
+
+def find_hass_config():
+    """Try to find HASS config."""
+    if 'HASSIO_TOKEN' in os.environ:
+        return '/config'
+
+    config_dir = default_hass_config_dir()
+
+    if os.path.isdir(config_dir):
+        return config_dir
+
+    return None
+
+
+class HassSafeConstructor(SafeConstructor):
+    """Hass specific SafeConstructor."""
+
+
+def _secret_yaml(loader, node):
+    """Load secrets and embed it into the configuration YAML."""
+    fname = os.path.join(os.path.dirname(loader.name), 'secrets.yaml')
+
+    try:
+        with open(fname, encoding='utf-8') as secret_file:
+            secrets = YAML(typ='safe').load(secret_file)
+    except FileNotFoundError:
+        raise ValueError("Secrets file {} not found".format(fname)) from None
+
+    try:
+        return secrets[node.value]
+    except KeyError:
+        raise ValueError("Secret {} not found".format(node.value)) from None
+
+
+def _stub_dict(constructor, node):
+    """Stub a constructor with a dictionary."""
+    return {}
+
+
+HassSafeConstructor.add_constructor('!include', _stub_dict)
+HassSafeConstructor.add_constructor('!env_var', _stub_dict)
+HassSafeConstructor.add_constructor('!secret', _secret_yaml)
+HassSafeConstructor.add_constructor('!include_dir_list', _stub_dict)
+HassSafeConstructor.add_constructor('!include_dir_merge_list', _stub_dict)
+HassSafeConstructor.add_constructor('!include_dir_named', _stub_dict)
+HassSafeConstructor.add_constructor('!include_dir_merge_named', _stub_dict)
+
+
+def load_hass_config(path):
+    """Load the HASS config."""
+    fname = os.path.join(path, 'configuration.yaml')
+
+    yaml = YAML(typ='safe')
+    # Compat with HASS
+    yaml.allow_duplicate_keys = True
+    # Stub HASS constructors
+    HassSafeConstructor.name = fname
+    yaml.Constructor = HassSafeConstructor
+
+    with open(fname, encoding='utf-8') as conf_file:
+        # If configuration file is empty YAML returns None
+        # We convert that to an empty dict
+        return yaml.load(conf_file) or {}
+
+
+def db_url_from_hass_config(path):
+    """Find the recorder database url from a HASS config dir."""
+    config = load_hass_config(path)
+    default = 'sqlite:///{}'.format(os.path.join(path, 'home-assistant_v2.db'))
+
+    recorder = config.get('recorder')
+
+    if not recorder:
+        return default
+
+    return recorder.get('db_url', default)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy>=1.14.3
 pandas>=0.23.0
 requests>=2.18.4
 SQLAlchemy>=1.2.8
+ruamel.yaml==0.15.78

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest-timeout==1.3.2
+pytest==4.0.0

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,1 +1,1 @@
-To do
+# To do

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,62 @@
+"""Tests for helpers package."""
+import os
+import tempfile
+from unittest.mock import patch
+
+from detective import helpers
+
+
+def test_find_hass_config():
+    """Test finding HASS config."""
+    with patch.dict(os.environ, {'HASSIO_TOKEN': 'yo'}):
+        assert helpers.find_hass_config() == '/config'
+
+    with patch.dict(os.environ, {}, clear=True), \
+            patch('detective.helpers.default_hass_config_dir',
+                  return_value='default-dir'), \
+            patch('os.path.isdir', return_value=True):
+        assert helpers.find_hass_config() == 'default-dir'
+
+    with patch.dict(os.environ, {}, clear=True), \
+            patch('os.path.isdir', return_value=False):
+        assert helpers.find_hass_config() is None
+
+
+def test_load_hass_config():
+    """Test loading hass config."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with open(os.path.join(tmpdir, 'configuration.yaml'), 'wt') as fp:
+            fp.write("""
+mock_secret: !secret some_secret
+mock_env: !env_var MOCK_ENV
+mock_dir_list: !include_dir_list ./zxc
+mock_dir_merge_list: !include_dir_merge_list ./zxc
+mock_dir_named: !include_dir_named ./zxc
+mock_dir_merge: !include_dir_merge_named ./zxc
+# Trigger duplicate error
+mock_secret: !secret other_secret
+        """)
+
+        with open(os.path.join(tmpdir, 'secrets.yaml'), 'wt') as fp:
+            fp.write("""
+some_secret: test-some-secret
+other_secret: test-other-secret
+        """)
+
+        config = helpers.load_hass_config(tmpdir)
+
+    assert config['mock_secret'] == 'test-other-secret'
+
+
+def test_db_url_from_hass_config():
+    """Test extracting recorder url from config."""
+    with patch('detective.helpers.load_hass_config', return_value={}):
+        assert helpers.db_url_from_hass_config('mock-path') == \
+            'sqlite:///mock-path/home-assistant_v2.db'
+
+    with patch('detective.helpers.load_hass_config', return_value={
+        'recorder': {
+            'db_url': 'mock-url'
+        }
+    }):
+        assert helpers.db_url_from_hass_config('mock-path') == 'mock-url'


### PR DESCRIPTION
This will automatically try to find the HASS config dir and extract the recorder DB url. Supports Hass.io and if user uses default config dir.

```python
db = detective.HassDatabase()
```

![image](https://user-images.githubusercontent.com/1444314/49281030-d53d5c80-f48b-11e8-9926-b05c82b51a4e.png)
