### PR TITLE
Split hass config detect, add users

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,30 +26,36 @@ Alternatively, to load from a cloud database we load from a json file containing
 
 ## Load the db data
 
-We use the DataParser class to load data from the database. This class performs the SQL queries and parses the returned data. The class holds the master pandas dataframe master_df.
-
-If you are running under Hass.io or are using the default configuration path, `HassDatabase` will be able to automatically detect your database url. If not, you can pass in either the `url` or `hass_config_path`.
+There are two different ways to initialize the HassDatabase. The easiest is with `db_from_hass_config`. This will initialize a HassDatabase based on the the information found in your Home Assistant config folder. It is able to automatically detect the configuration directiory if you're running under Hass.io or use the default Home Assistant configuration directory. It's also possible to pass the path in.
 
 ```python
-%%time
-from detective.core import HassDatabase
-# Example invocations
+from detective.core import db_from_hass_config
+
 # Auto detect
-db = HassDatabase()
-# using DB url
-db = HassDatabase(url=DB_URL)
-# Using HASS config path
-db = HassDatabase(hass_config_path='/home/homeassistant/config')
-# Auto detect and not prefetching entities
-db = HassDatabase(fetch_entities=False)
+db = db_from_hass_config()
+
+# Pass in path to config
+db = db_from_hass_config("/home/homeassistant/config")
 ```
 
-    Successfully connected to sqlite:////Users/robincole/Documents/Home-assistant_database/home-assistant_v2.db
-    There are 261 entities with data
-    CPU times: user 525 ms, sys: 2.44 s, total: 2.97 s
-    Wall time: 13.3 s
+If you are using this package on a different computer than the one that is running Home Assistant, you need to initialize the HassDatabase directly with the correct connection string.
 
+```python
+from detective.core import HassDatabase
 
+# Using DB url
+db = HassDatabase("mysql://scott:tiger@localhost/test")
+```
+
+Both invocations will use the DataParser class to load data from the database. This class performs the SQL queries and parses the returned data. The class holds the master pandas dataframe master_df.
+
+Both methods accept additional keyword arguments to influence how the class is initialized.
+
+| Argument | Description |
+| -------- | ----------- |
+| `fetch_entities` | Boolean to indicate if we should fetch the entities when constructing the database. If not, you will have to call `db.fetch_entities()` at a later stage before being able to use `self.entities` and `self.domains`.
+
+## Use the db data
 
 ```python
 db.domains
@@ -859,3 +865,33 @@ ax.set_title('Activity at home by day and time category')
 
 
 ![png](https://github.com/robmarkcole/HASS-data-detective/blob/master/docs/images/output_54_1.png)
+
+
+## Auth helpers
+
+When querying the database, you might end up with user IDs and refresh token IDs. We've included a helper to help load the auth from Home Assistant and help you process this data.
+
+```python
+from detective.helpers import auth_from_hass_config
+
+auth = auth_from_hass_config()
+```
+
+```python
+{
+    "users": {
+        "user-id": {
+            "id": "id of user",
+            "name": "Name of user",
+        }
+    },
+    "refresh_tokens_to_users": {
+        "refresh-token-id": {
+            "id": "id of token",
+            "user": "user object related to token",
+            "client_name": "Name of client that created token",
+            "client_id": "ID of client that created token",
+        }
+    }
+}
+```

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,7 +1,10 @@
 """Tests for helpers package."""
+import json
 import os
 import tempfile
-from unittest.mock import patch
+from unittest.mock import patch, mock_open
+
+import pytest
 
 from detective import helpers
 
@@ -18,8 +21,9 @@ def test_find_hass_config():
         assert helpers.find_hass_config() == 'default-dir'
 
     with patch.dict(os.environ, {}, clear=True), \
-            patch('os.path.isdir', return_value=False):
-        assert helpers.find_hass_config() is None
+            patch('os.path.isdir', return_value=False), \
+            pytest.raises(ValueError):
+        helpers.find_hass_config()
 
 
 def test_load_hass_config():
@@ -60,3 +64,41 @@ def test_db_url_from_hass_config():
         }
     }):
         assert helpers.db_url_from_hass_config('mock-path') == 'mock-url'
+
+
+def test_auth_from_hass_config():
+    """Test extracting users from hass config."""
+    mopen = mock_open(read_data=json.dumps({
+        'key': 'auth',
+        'version': 1,
+        'data': {
+            'users': [{
+                'id': 'mock-user-id',
+                'name': 'mock-user-name'
+            }],
+            'refresh_tokens': [{
+                'id': 'mock-refresh-id',
+                'user_id': 'mock-user-id',
+                'client_name': 'mock-client-name',
+                'client_id': 'mock-client-id',
+            }]
+        }
+    }))
+
+    with patch('detective.helpers.open', mopen):
+        auth = helpers.auth_from_hass_config('/some/path')
+
+    assert auth['users'] == {
+        'mock-user-id': {
+            'id': 'mock-user-id',
+            'name': 'mock-user-name'
+        }
+    }
+    assert auth['refresh_tokens_to_users'] == {
+        'mock-refresh-id': {
+            'id': 'mock-refresh-id',
+            'user': auth['users']['mock-user-id'],
+            'client_id': 'mock-client-id',
+            'client_name': 'mock-client-name',
+        }
+    }


### PR DESCRIPTION
Split the auto-detect config path from `HassDatabase` contructor into a new method `db_from_hass_config `. Updated README accordingly.

Added new helper `users_from_hass_config` to load auth info from the configuration directory.