### PR TITLE
Only get binary data

### DIFF
--- a/detective/core.py
+++ b/detective/core.py
@@ -265,9 +265,9 @@ class BinarySensors():
     Class handling binary sensor data.
     """
     def __init__(self, master_df):
-        # Extract all the numerical sensors
+        # Extract all the binary sensors with binary values
         binary_df = master_df.query(
-            'domain == "binary_sensor"')
+            'domain == "binary_sensor" & (state == "on" | state == "off")')
 
         # List of sensors
         entities = list(


### PR DESCRIPTION
A binary sensor can apparently also have an empty state `''` or `unavailable` (and maybe more?) we are not interested in those states.

![image](https://user-images.githubusercontent.com/5662298/50112249-1204a400-023f-11e9-9750-5b6265ef3524.png)

Fixes https://github.com/robmarkcole/HASS-data-detective/issues/56