### PR TITLE
Use index to query available entities

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+from unittest.mock import patch
+
+import pytest
+
+from detective.core import HassDatabase
+
+
+@pytest.fixture
+def mock_db():
+    with patch('detective.core.create_engine'):
+        return HassDatabase('mock://db')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from detective.core import get_db_type, stripped_db_url
 
 
@@ -12,3 +14,17 @@ def test_stripped_db_url():
         'mysql://paulus@localhost'
     assert stripped_db_url('mysql://paulus:password@localhost') == \
         'mysql://paulus:***@localhost'
+
+
+def test_fetch_entities(mock_db):
+    with patch.object(mock_db, 'perform_query', return_value=[
+        ['light.kitchen'],
+        ['light.living_room'],
+        ['switch.ac'],
+    ]):
+        mock_db.fetch_entities()
+
+    assert mock_db.entities == {
+        'light': ['light.kitchen', 'light.living_room'],
+        'switch': ['switch.ac'],
+    }


### PR DESCRIPTION
By dropping the `count` in the `fetch_entities` query, SQL will be able to leverage an index.

![image](https://user-images.githubusercontent.com/1444314/50426414-7356f380-088d-11e9-9c4f-309d96e5663e.png)
