### PR TITLE
add failing test where secrets.yaml is not found and fix it

### DIFF
--- a/detective/config.py
+++ b/detective/config.py
@@ -3,9 +3,13 @@ Helper functions for config.
 """
 import os
 from pathlib import Path
+from typing import Optional
 
 from ruamel.yaml import YAML
 from ruamel.yaml.constructor import SafeConstructor
+
+
+_CONFIGURATION_PATH: Optional[Path] = None
 
 
 def default_hass_config_dir():
@@ -40,10 +44,15 @@ def _secret_yaml(loader, node):
 
     # Recursively search for the secrets.yaml file
     # this might be needed when a yaml file is included like
-    # `!included folder/file.yaml`.
+    # `!included folder/file.yaml`. Same rules as
+    # https://www.home-assistant.io/docs/configuration/secrets/#debugging-secrets
     fname = dirpath / "secrets.yaml"
     for _ in range(len(dirpath.parts)):
-        if fname.exists():
+        if fname.exists() or (
+            _CONFIGURATION_PATH is not None
+            and _CONFIGURATION_PATH.exists()
+            and dirpath.samefile(_CONFIGURATION_PATH)
+        ):
             break
         dirpath = dirpath.parent
         fname = dirpath / "secrets.yaml"
@@ -114,6 +123,8 @@ def load_yaml(fname):
 
 def db_url_from_hass_config(path):
     """Find the recorder database url from a HASS config dir."""
+    global _CONFIGURATION_PATH
+    _CONFIGURATION_PATH = Path(path).resolve()
     config = load_hass_config(path)
     default_path = os.path.join(path, "home-assistant_v2.db")
     default_url = "sqlite:///{}".format(default_path)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,7 +34,8 @@ def test_load_hass_config():
                 """
 mock_secret: !secret some_secret
 included: !include included.yaml
-nested_included: !include includes/nested_included.yaml
+nested_with_secret: !include includes/with_secret.yaml
+nested_without_secret: !include includes/without_secret.yaml
 mock_env: !env_var MOCK_ENV
 mock_env: !env_var MOCK_ENV
 mock_dir_list: !include_dir_list ./zxc
@@ -55,25 +56,19 @@ another_secret: test-another-secret
         """
             )
         with (p / "included.yaml").open("wt") as fp:
-            fp.write(
-                """
-some: value
-        """
-            )
+            fp.write("some: value")
         includes_dir = p / "includes"
         includes_dir.mkdir(exist_ok=True)
-        with (includes_dir / "nested_included.yaml").open("wt") as fp:
-            fp.write(
-                """
-some: !secret another_secret
-        """
-            )
-
+        with (includes_dir / "with_secret.yaml").open("wt") as fp:
+            fp.write("some: !secret another_secret")
+        with (includes_dir / "without_secret.yaml").open("wt") as fp:
+            fp.write("some: value")
         configuration = config.load_hass_config(tmpdir)
 
     # assert configuration["mock_secret"] == "test-other-secret"  # TODO: fix
     assert configuration["included"] == {"some": "value"}
-    assert configuration["nested_included"] == {"some": "test-another-secret"}
+    assert configuration["nested_with_secret"] == {"some": "test-another-secret"}
+    assert configuration["nested_without_secret"] == {"some": "value"}
 
 
 def test_db_url_from_hass_config():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -73,6 +73,7 @@ some: !secret another_secret
 
     # assert configuration["mock_secret"] == "test-other-secret"  # TODO: fix
     assert configuration["included"] == {"some": "value"}
+    assert configuration["nested_included"] == {"some": "test-another-secret"}
 
 
 def test_db_url_from_hass_config():


### PR DESCRIPTION
This (currently failing) test reproduces the problem described in https://github.com/robmarkcole/HASS-data-detective/issues/85.

@balloob, would you know where this goes wrong?

I have added a recursive search in https://github.com/robmarkcole/HASS-data-detective/pull/119/commits/aa1fcfb7a2ce312a6c8e8a8d6104ea042d65d6bd, however, I do not know if this is the proper solution.