### PR TITLE
Allow disabling limit for data fetching from database.

### DIFF
--- a/detective/core.py
+++ b/detective/core.py
@@ -91,6 +91,10 @@ class HassDatabase:
     def fetch_all_sensor_data(self, limit=50000) -> pd.DataFrame:
         """
         Fetch data for all sensor entities.
+        
+        Arguments:
+        - limit (default: 50000): Limit the maximum number of state changes loaded.
+            If None, there is no limit.
         """
         query = f"""
             SELECT domain, entity_id, state, last_changed, attributes
@@ -100,8 +104,8 @@ class HassDatabase:
             AND
                 state NOT IN ('unknown', 'unavailable')
             ORDER BY last_changed DESC
-            LIMIT {limit}
             """
+        if limit is not None: query += f'LIMIT {limit}'
         df = pd.read_sql_query(query, self.url)
         print(f"The returned Pandas dataframe has {df.shape[0]} rows of data.")
         return df
@@ -109,6 +113,10 @@ class HassDatabase:
     def fetch_all_data_of(self, sensors: Tuple[str], limit=50000) -> pd.DataFrame:
         """
         Fetch data for sensors.
+        
+        Arguments:
+        - limit (default: 50000): Limit the maximum number of state changes loaded.
+            If None, there is no limit.
         """
         sensors_str = str(tuple(sensors))
         if len(sensors) == 1:
@@ -122,8 +130,8 @@ class HassDatabase:
             AND
                 state NOT IN ('unknown', 'unavailable')
             ORDER BY last_changed DESC
-            LIMIT {limit}
             """
+        if limit is not None: query += f'LIMIT {limit}'
         df = pd.read_sql_query(query, self.url)
         print(f"The returned Pandas dataframe has {df.shape[0]} rows of data.")
         return df


### PR DESCRIPTION
Allow `limit=None` for `fetch_all_data_of` and `fetch_all_sensor_data`.