### PR TITLE
Add get_attributes parameter to JOIN the attributes table to requests

### DIFF
--- a/detective/core.py
+++ b/detective/core.py
@@ -88,52 +88,86 @@ class HassDatabase:
         self.entities = [e[0] for e in response]
         print(f"There are {len(self.entities)} entities with data")
 
-    def fetch_all_sensor_data(self, limit=50000) -> pd.DataFrame:
+    def fetch_all_sensor_data(self, limit=50000, get_attributes=False) -> pd.DataFrame:
         """
         Fetch data for all sensor entities.
 
         Arguments:
         - limit (default: 50000): Limit the maximum number of state changes loaded.
             If None, there is no limit.
+        - get_attributes: If True, LEFT JOIN the attributes table to retrieve event's attributes.
         """
-        query = f"""
-            SELECT entity_id, state, last_updated
-            FROM states
+        
+        if get_attributes:
+            query = """
+                SELECT entity_id, state, last_updated, shared_attrs
+            """
+        else:
+            query = """
+                SELECT entity_id, state, last_updated
+            """
+        
+        query += "FROM states"
+        
+        if get_attributes:
+            query += """
+                LEFT JOIN state_attributes ON states.attributes_id = state_attributes.attributes_id
+            """
+            
+        query += """
             WHERE
                 entity_id  LIKE '%sensor%'
             AND
                 state NOT IN ('unknown', 'unavailable')
             ORDER BY last_updated DESC
             """
+        
         if limit is not None:
             query += f"LIMIT {limit}"
         df = pd.read_sql_query(query, self.url)
         print(f"The returned Pandas dataframe has {df.shape[0]} rows of data.")
         return df
 
-    def fetch_all_data_of(self, sensors: Tuple[str], limit=50000) -> pd.DataFrame:
+    def fetch_all_data_of(self, sensors: Tuple[str], limit=50000, get_attributes=False) -> pd.DataFrame:
         """
         Fetch data for sensors.
 
         Arguments:
         - limit (default: 50000): Limit the maximum number of state changes loaded.
             If None, there is no limit.
+        - get_attributes: If True, LEFT JOIN the attributes table to retrieve event's attributes.
         """
         sensors_str = str(tuple(sensors))
         if len(sensors) == 1:
             sensors_str = sensors_str.replace(",", "")
 
-        query = f"""
-            SELECT entity_id, state, last_updated
-            FROM states
+        if get_attributes:
+            query = """
+                SELECT entity_id, state, last_updated, shared_attrs
+            """
+        else:
+            query = """
+                SELECT entity_id, state, last_updated
+            """
+
+        query += "FROM states"
+        
+        if get_attributes:
+            query += """
+                LEFT JOIN state_attributes ON states.attributes_id = state_attributes.attributes_id
+            """
+            
+        query += f"""
             WHERE
                 entity_id IN {sensors_str}
             AND
                 state NOT IN ('unknown', 'unavailable')
             ORDER BY last_updated DESC
             """
+
         if limit is not None:
             query += f"LIMIT {limit}"
+            
         df = pd.read_sql_query(query, self.url)
         print(f"The returned Pandas dataframe has {df.shape[0]} rows of data.")
         return df


### PR DESCRIPTION
The database structure has changed in HA so that attributes are now stored in a separate table. This PR adds a parameter "get_attributes" to data retrieving methods which performs a LEFT JOIN to also retrieve attributes for states, if requested. 