### PR TITLE
Removed error ignore, as per deprecation notice

### DIFF
--- a/detective/functions.py
+++ b/detective/functions.py
@@ -9,7 +9,7 @@ def format_dataframe(df: pd.DataFrame) -> pd.DataFrame:
     """Convert states to numeric where possible and format the last_changed."""
     df["state"] = pd.to_numeric(df["state"], errors="coerce")
     df["last_updated_ts"] = pd.to_datetime(
-        df["last_updated_ts"].values, errors="ignore", utc=True
+        df["last_updated_ts"].values, utc=True
     ).tz_localize(None)
     df = df.dropna()
     return df


### PR DESCRIPTION
FutureWarning: errors='ignore' is deprecated and will raise in a future version. 